### PR TITLE
Build doxygen documentation inside the docs

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,51 @@
+name: Doxygen GitHub Pages Deploy Action
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install gcc-10 g++-10 mpich doxygen
+
+      - name: Configure CMake
+        env:
+          MPICH_CXX: g++-10
+          MPICH_CC: gcc-10
+        run: |
+          cmake -S ${{github.workspace}} \
+                -B ${{github.workspace}}/build \
+                -DCMAKE_CXX_COMPILER=mpicxx \
+                -DCMAKE_C_COMPILER=mpicc \
+                -DENABLE_PARMETIS=OFF \
+                -DENABLE_PUMI=OFF \
+                -DENABLE_ZOLTAN=OFF \
+                -DIS_TESTING=OFF \
+                -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/build/install
+
+      - name: Generate Doc
+        run: doxygen ${{github.workspace}}/build/Doxyfile
+
+      - name: Commit and push if documentation changed
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git add docs/html
+          if ! git diff --cached --quiet; then
+            git commit -m "Update Doxygen documentation"
+            git push origin master
+          else
+            echo "No documentation changes to commit."
+          fi

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -5,11 +5,14 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-22.04
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -34,18 +37,30 @@ jobs:
                 -DENABLE_ZOLTAN=OFF \
                 -DIS_TESTING=OFF \
                 -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/build/install
+      
+      - name: Build jekyll site
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./docs/_site
 
       - name: Generate Doc
         run: doxygen ${{github.workspace}}/build/Doxyfile
 
-      - name: Commit and push if documentation changed
-        run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
-          git add docs/html
-          if ! git diff --cached --quiet; then
-            git commit -m "Update Doxygen documentation"
-            git push origin master
-          else
-            echo "No documentation changes to commit."
-          fi
+      - name: Copy files to _site
+        run: sudo cp -r docs/html ./docs/_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs/_site
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+    environment:
+      name: github-pages

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 permissions:
-  contents: write
+  contents: read
   pages: write
   id-token: write
 

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = doc
+OUTPUT_DIRECTORY       = docs
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/docs/index.html
+++ b/docs/index.html
@@ -73,7 +73,7 @@ and then improving the partition for multiple criteria with a diffusive procedur
 </h3>
   <h4>API Documentation</h4>
 
-    <a href="http://www.scorec.rpi.edu/engpar/"> Doxygen Documentation</a>
+    <a href="html/index.html"> Doxygen Documentation</a>
 
   <h4>Publications</h4>
     <p>


### PR DESCRIPTION
Built the current Doxygen documentation inside the docs directory and fixed the broken Doxygen URL in the GitHub Pages-hosted documentation.

PS: If necessary, we could maintain the entire documentation (including Jekyll and Doxygen) in a separate branch.