### PR TITLE
Check the if mallinfo2 exisits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,5 +114,13 @@ endif()
 
 add_subdirectory(test)
 
+#check for mallinfo2
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+  include(CheckCXXSymbolExists)
+  check_cxx_symbol_exists(mallinfo2 "malloc.h" ENGPAR_HAS_MALLINFO2)
+  if(ENGPAR_HAS_MALLINFO2)
+	  target_compile_definitions(engpar_support PUBLIC -DENGPAR_HAS_MALLINFO2)
+  endif()
+endif()
 
 bob_end_package()

--- a/support/engpar_memory.cpp
+++ b/support/engpar_memory.cpp
@@ -14,7 +14,11 @@ double EnGpar_Peak_Memory()
 #include <malloc.h>
 double EnGPar_Peak_Memory()
 {
+#if defined(__GNUC__) && defined(ENGPAR_HAS_MALLINFO2)
+  return mallinfo2().arena;
+#elif defined(__GNUC__)
   return mallinfo().arena;
+#endif
 }
 
 #else


### PR DESCRIPTION
 Use `mallinfo2` as a replacement for `mallinfo` when available to avoid using deprecated code."